### PR TITLE
Multi OPC Server and auto-reconnect

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,12 +15,34 @@ $ npm install
 
 ## Configuration
 
-Modify the `config.toml` file to match your configuration. The input section should contain the url of the OPC server (no advanced authentication supported yet).
+Modify the `config.toml` file to match your configuration. The input section should contain the url of the OPC server (no advanced authentication supported yet). For each input OPC server you can configure the following entries.
 
 ```
-[input]
+[[input]]
 url             = "opc.tcp://opcua.demo-this.com:51210/UA/SampleServer"
 failoverTimeout = 5000     # time to wait before reconnection in case of failure
+```
+
+Then, for each OPC value you want to log from this server, repeat the following in the config file:
+
+```
+# A polled node:
+[[input.measurements]]
+name               = "Int32polled"
+tags               = { tag1 = "test", tag2 = "AB43" }
+nodeId             = "ns=2;i=10849"
+collectionType     = "polled"
+pollRate           = 20     # samples / minute.
+deadbandAbsolute   = 0      # Absolute max difference for a value not to be collected
+deadbandRelative   = 0.0    # Relative max difference for a value not to be collected
+
+# A monitored node
+[[input.measurements]]
+name               = "Int32monitored"
+tags               = { tag1 = "test", tag2 = "AB43" }
+nodeId             = "ns=2;i=10849"
+collectionType     = "monitored"
+monitorResolution  = 1000    # ms 
 ```
 
 In the output section, specify the connection details for influxdb:
@@ -39,28 +61,6 @@ failoverTimeout  = 10000     # Time after which the logger will reconnect
 bufferMaxSize    = 64        # Max size of the local db in MB. TODO.
 writeInterval    = 3000      # Interval of batch writes.
 writeMaxPoints   = 1000      # Max point per POST request.
-```
-
-Then, for each OPC value you want to log, repeat the following in the config file, d:
-
-```
-# A polled node:
-[[measurements]]
-name               = "Int32polled"
-tags               = { tag1 = "test", tag2 = "AB43" }
-nodeId             = "ns=2;i=10849"
-collectionType     = "polled"
-pollRate           = 20     # samples / minute.
-deadbandAbsolute   = 0      # Absolute max difference for a value not to be collected
-deadbandRelative   = 0.0    # Relative max difference for a value not to be collected
-
-# A monitored node
-[[measurements]]
-name               = "Int32monitored"
-tags               = { tag1 = "test", tag2 = "AB43" }
-nodeId             = "ns=2;i=10849"
-collectionType     = "monitored"
-monitorResolution  = 1000    # ms 
 ```
 
 ## Run

--- a/config.toml
+++ b/config.toml
@@ -21,7 +21,7 @@ writeMaxPoints   = 1000
 name               = "Int32polled"
 dataType           = "number"
 tags               = { tag1 = "test", tag2 = "AB43" }
-nodeId             = "ns=37;s=10849"
+nodeId             = "ns=2;i=10849"
 collectionType     = "polled"
 pollRate           = 60     # samples / minute.
 deadbandAbsolute   = 0      # Absolute max difference for a value not to be collected

--- a/config.toml
+++ b/config.toml
@@ -1,6 +1,54 @@
-[input]
+[[input]]
 url             = "opc.tcp://opcua.demo-this.com:51210/UA/SampleServer"
 failoverTimeout = 5000 # time to wait before reconnection in case of failure
+
+# A polled node:
+[[input.measurements]]
+name               = "Int32polled"
+dataType           = "number"
+tags               = { tag1 = "test", tag2 = "AB43" }
+nodeId             = "ns=2;i=10849"
+collectionType     = "polled"
+pollRate           = 60     # samples / minute.
+deadbandAbsolute   = 0      # Absolute max difference for a value not to be collected
+deadbandRelative   = 0.0    # Relative max difference for a value not to be collected
+
+# A monitored node
+[[input.measurements]]
+name               = "Int32monitored"
+dataType           = "number"
+tags               = { tag1 = "test", tag2 = "AB43" }
+nodeId             = "ns=2;i=10849"
+collectionType     = "monitored"
+monitorResolution  = 1000    # ms
+deadbandAbsolute   = 0 		# Absolute max difference for a value not to be collected
+deadbandRelative   = 0    	# Relative max difference for a value not to be collected
+
+[[input]]
+url             = "opc.tcp://opcua.demo-this.com:51210/UA/SampleServer"
+failoverTimeout = 5000 # time to wait before reconnection in case of failure
+
+# A polled node:
+[[input.measurements]]
+name               = "Int32polled"
+dataType           = "number"
+tags               = { tag1 = "test", tag2 = "AB43" }
+nodeId             = "ns=2;i=10849"
+collectionType     = "polled"
+pollRate           = 60     # samples / minute.
+deadbandAbsolute   = 0      # Absolute max difference for a value not to be collected
+deadbandRelative   = 0.0    # Relative max difference for a value not to be collected
+
+# A monitored node
+[[input.measurements]]
+name               = "Int32monitored"
+dataType           = "number"
+tags               = { tag1 = "test", tag2 = "AB43" }
+nodeId             = "ns=2;i=10849"
+collectionType     = "monitored"
+monitorResolution  = 1000    # ms
+deadbandAbsolute   = 0 		# Absolute max difference for a value not to be collected
+deadbandRelative   = 0    	# Relative max difference for a value not to be collected
 
 [output]
 name             = "influx_1"
@@ -15,25 +63,3 @@ failoverTimeout  = 10000
 bufferMaxSize    = 64
 writeInterval    = 3000
 writeMaxPoints   = 1000
-
-# A polled node:
-[[measurements]]
-name               = "Int32polled"
-dataType           = "number"
-tags               = { tag1 = "test", tag2 = "AB43" }
-nodeId             = "ns=2;i=10849"
-collectionType     = "polled"
-pollRate           = 60     # samples / minute.
-deadbandAbsolute   = 0      # Absolute max difference for a value not to be collected
-deadbandRelative   = 0.0    # Relative max difference for a value not to be collected
-
-# A monitored node
-[[measurements]]
-name               = "Int32monitored"
-dataType           = "number"
-tags               = { tag1 = "test", tag2 = "AB43" }
-nodeId             = "ns=2;i=10849"
-collectionType     = "monitored"
-monitorResolution  = 1000    # ms
-deadbandAbsolute   = 0 		# Absolute max difference for a value not to be collected
-deadbandRelative   = 0    	# Relative max difference for a value not to be collected

--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
 	"author": "Jeroen Coussement (@coussej)",
 	"dependencies": {    
 		"async": "1.5.2",
-		"influx": "4.1.0",
-		"node-opcua": "0.0.52",
+		"influx": "5.0.7",
+		"node-opcua": "0.4.5",
 		"node-schedule": "1.1.0",
 		"toml": "2.3.0",
 		"nedb": "1.8.0"

--- a/readpump.js
+++ b/readpump.js
@@ -63,7 +63,7 @@ ReadPump.prototype.ExecuteOPCUAReadRequest = function(nodes, useSourceTimestamp,
         return;
     }
 
-    self.uaSession.read(nodes, 0, function(err, nodesToRead, dataValues) {
+    self.uaSession.read(nodes, 0, function(err, dataValues) {
         if (err) {
             callback(err, []);
             return;
@@ -71,7 +71,7 @@ ReadPump.prototype.ExecuteOPCUAReadRequest = function(nodes, useSourceTimestamp,
         let results = []
         dataValues.forEach(
             function(dv, i) {
-                let res = dataValueToPoint(nodesToRead[i], dv, t)
+                let res = dataValueToPoint(nodes[i], dv, t)
                 results.push(res);
             }
         );


### PR DESCRIPTION
For my use case I need to log data form diffrent opc ua server so I made a few changes that you can config multiple opc ua endpoints with their datapoints you want to log in the config file.

When a opc ua server restarts the connection should be reestablished automatically with all the monitored itmes. The opc ua npm package unfortunately dosen't do that. I tested with python-opcua Server. The solution is a little bit hacky: When the opc ua server comes back up the client object gets newly initialized.